### PR TITLE
Improve release creation triggers and add caching to CircleCI toolbox distribution example

### DIFF
--- a/.circleci/ToolboxDistribution.yml
+++ b/.circleci/ToolboxDistribution.yml
@@ -25,7 +25,8 @@ jobs:
     steps:
       - checkout
       
-      - matlab/install
+      - matlab/install:
+          cache: true
       
       # Runs build to create MEX file and then run tests
       - matlab/run-build:
@@ -48,7 +49,8 @@ jobs:
     steps:
       - checkout
       
-      - matlab/install
+      - matlab/install:
+          cache: true
       
       # Downloads all mex files from previous job
       - attach_workspace:

--- a/.github/workflows/ToolboxDistribution.yml
+++ b/.github/workflows/ToolboxDistribution.yml
@@ -3,6 +3,8 @@ name: Compile, Test and Release toolbox
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'v*'
   pull_request:
     branches: [ main ]
 
@@ -77,7 +79,8 @@ jobs:
 
       # The packaged toolbox is distributed as a GitHub release
       - name: Create release and upload asset
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          gh release create ${{github.run_id}} --title "Cross-Platform Array Product Toolbox" toolbox.mltbx
+          gh release create gh-${{github.ref_name}} --title "Cross-Platform Array Product Toolbox" toolbox.mltbx
         env:
           GH_TOKEN: ${{ github.token }}

--- a/AzureDevOps/ToolboxDistribution.yml
+++ b/AzureDevOps/ToolboxDistribution.yml
@@ -1,3 +1,16 @@
+trigger:
+  branches:
+    include:
+      - main
+  tags:
+    include:
+      - 'v*'
+
+pr:
+  branches:
+    include:
+      - main
+
 jobs:
   # This job compiles MEX files and runs tests across different platforms
   - job: CompileAndTestMex
@@ -62,10 +75,11 @@ jobs:
       
       # The packaged toolbox is distributed as a GitHub release
       - task: GitHubRelease@1
+        condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
         inputs:
           gitHubConnection: advanced-ci-configuration-examples
           title: "Cross-Platform Array Product Toolbox"
           assets: 'toolbox.mltbx'
           tagSource: 'userSpecifiedTag'
-          tag: '$(Build.BuildNumber)'
+          tag: 'azure-$(Build.SourceBranchName)'
     dependsOn: CompileAndTestMex


### PR DESCRIPTION
This PR closes #5 and #7.

- Updates the GitHub and Azure workflow triggers so that releases are only created when a tag is pushed to the main branch, preventing unintended releases from other commits.
- Adds the new `cache` parameter in the `matlab/install` step within the toolbox distribution example.