### PR TITLE
Add config.yml that dispatches to other CircleCI examples through dynamic configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2.1
+setup: true
+orbs:
+  continuation: circleci/continuation@1
+
+parameters:
+  workflow:
+    type: enum
+    default: cross-platform-builder
+    enum: [cross-platform-builder, test-splitting, toolbox-distribution]
+
+jobs:
+  select-config:
+    executor: continuation/default
+    steps:
+      - checkout
+      - when:
+          condition:
+            equal: [cross-platform-builder, << pipeline.parameters.workflow >>]
+          steps:
+            - continuation/continue:
+                configuration_path: .circleci/CrossPlatformBuilder.yml
+      - when:
+          condition:
+            equal: [test-splitting, << pipeline.parameters.workflow >>]
+          steps:
+            - continuation/continue:
+                configuration_path: .circleci/TestSplitting.yml
+      - when:
+          condition:
+            equal: [toolbox-distribution, << pipeline.parameters.workflow >>]
+          steps:
+            - continuation/continue:
+                configuration_path: .circleci/ToolboxDistribution.yml
+
+workflows:
+  setup:
+    jobs:
+      - select-config


### PR DESCRIPTION
Use dynamic pipeline configuration to fix the fact that the CircleCI workflow isn't working.

The config.yml takes a parameter for which workflow to run and defaults to the cross-platform builder workflow.

Addresses https://github.com/mathworks/advanced-ci-configuration-examples/issues/13